### PR TITLE
Rename arcsi.py to arcsi-script.py and change bat file to run it

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,24 +43,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/arcsi.py.bat
+++ b/recipe/arcsi.py.bat
@@ -1,2 +1,2 @@
 @echo off
-python "%~dp0\arcsi.py" %*
+python "%~dp0\arcsi-script.py" %*

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,13 @@
 %PYTHON% setup.py install
 if errorlevel 1 exit 1
 
+REM rename arcsi.py to arcsi-script.py so it doesn't
+REM get picked up when user runs arcsi.py 
+REM (the .bat file will due to the way Windows works)
+move %SCRIPTS%\arcsi.py %SCRIPTS%\arcsi-script.py
+if errorlevel 1 exit 1
+
 REM copy over batch file that calls the python on the path
-REM and runs arcsi.py wih the command line params given
+REM and runs arcsi-script.py wih the command line params given
 copy %RECIPE_DIR%\arcsi.py.bat %SCRIPTS%\
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d92c3023923a2e9c9235d92307a560e519095748c8e7700dc7956510f74b40fe
 
 build:
-  number: 1
+  number: 2
   # Windows recipe includes .bat file copy so use bld.bat
   script: python setup.py install  # [unix]
   # rsgislib not available due to mpfr only supporting vc14 and above


### PR DESCRIPTION
This means `arcsi.py.bat` will always get run when the user enters `arcsi.py` on Windows. Previously `arcsi.py` was getting run directly and which version of Python gets used in this case can be random.

`arcsi.py.bat` ensures conda Python is used.

xref: https://github.com/conda-forge/arcsi-feedstock/issues/4